### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-telegram.yml
+++ b/.github/workflows/build-telegram.yml
@@ -1,4 +1,6 @@
 name: Download and Patch Modules
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/apk-tweak/security/code-scanning/3](https://github.com/Ven0m0/apk-tweak/security/code-scanning/3)

To remediate, add a `permissions` block at the workflow root (directly under the `name:` and before `on:`), setting the minimal required privileges. As a safe starting point, set `contents: read`, which gives only read access to repository contents via `GITHUB_TOKEN`. Then, if any job or step requires more (such as creating/deleting releases or tags), you can increase only the necessary job-specific permissions. For this fix, you'll add the recommended minimal block at the top of the workflow (`contents: read`), following the CodeQL suggestion.

Edits are confined to the `.github/workflows/build-telegram.yml` file. Add the block after the `name:` line and before `on:`. No new dependencies or imports are required since this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
