### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Check-releases.yml
+++ b/.github/workflows/Check-releases.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   check-client-releases:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/apk-tweak/security/code-scanning/1](https://github.com/Ven0m0/apk-tweak/security/code-scanning/1)

To fix this issue, we should add a `permissions` block to explicitly define the minimal permissions necessary for the job. 

- Since this workflow pushes changes to the repository (writes to a file, commits, and pushes), it requires `contents: write`. 
- It also dispatches another workflow via the API using the `GITHUB_TOKEN`, which requires `actions: write`. 
- No other permissions appear needed.

Therefore, add the following block to the job (or root level): 
```yaml
permissions:
  contents: write
  actions: write
```
This can be added at the root (top) of the YAML file to apply to all jobs, or directly under the `check-client-releases` job definition at line 10 to only grant these to this job. Adding it at the job level is usually preferable unless multiple jobs share the same needs. 

No other imports, method changes, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
