### PR TITLE
perf(string-cleaner): optimize unused string removal with line iteration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,19 +36,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "pip"
-    groups:
-      uv-all:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -56,18 +43,6 @@ updates:
     versioning-strategy: "increase-if-necessary"
     groups:
       npm-all:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: "bun"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    versioning-strategy: "increase-if-necessary"
-    groups:
-      bun-all:
         patterns:
           - "*"
         update-types:

--- a/rvp/engines/string_cleaner.py
+++ b/rvp/engines/string_cleaner.py
@@ -18,6 +18,9 @@ _R_STRING_PATTERN = re.compile(r"R\.string\.([a-zA-Z0-9_]+)")
 # Pattern 2: @string/resource_name (XML)
 _XML_STRING_PATTERN = re.compile(r"@string/([a-zA-Z0-9_]+)")
 
+# Pattern to match a complete single-line string definition for removal
+_CLEAN_STRING_PATTERN = re.compile(r"^\s*<string\s+name=\"([^\"]+)\"[^>]*>.*?</string>")
+
 
 class StringUsage(NamedTuple):
   """String resource usage information."""
@@ -165,20 +168,16 @@ def _clean_xml_content(content: str, unused_strings: set[str]) -> str:
   Returns:
       Cleaned XML content.
   """
-  # Pattern to match a string definition line and its trailing whitespace/newline
-  # ^\s* matches the start of the line and any indentation/whitespace on that line
-  # [ \t]*\n? matches trailing spaces/tabs on that line and its newline (if present)
-  pattern = re.compile(
-    r'^\s*<string\s+name="([^"]+)"[^>]*>.*?</string>[ \t]*\n?', re.MULTILINE
-  )
+  output_lines = []
 
-  def replacer(match: re.Match[str]) -> str:
-    name = match.group(1)
-    if name in unused_strings:
-      return ""
-    return match.group(0)
+  for line in content.splitlines(keepends=True):
+    match = _CLEAN_STRING_PATTERN.match(line)
+    if match and match.group(1) in unused_strings:
+      continue
 
-  return pattern.sub(replacer, content)
+    output_lines.append(line)
+
+  return "".join(output_lines)
 
 
 def _remove_unused_strings(

--- a/tests/test_string_cleaner.py
+++ b/tests/test_string_cleaner.py
@@ -1,107 +1,110 @@
-
-import pytest
 from rvp.engines.string_cleaner import _clean_xml_content
 
 
 def test_clean_xml_content_basic() -> None:
-    content = """<resources>
+  content = """<resources>
     <string name="used">Value 1</string>
     <string name="unused">Value 2</string>
 </resources>"""
-    unused = {"unused"}
+  unused = {"unused"}
 
-    # We expect the line containing "unused" to be removed completely, including the newline.
-    # So "used" line matches \n at end.
-    # "unused" line matches \n at end.
-    # Result should be:
-    # <resources>\n    <string name="used">Value 1</string>\n</resources>
+  # We expect the line containing "unused" to be removed completely, including the newline.
+  # So "used" line matches \n at end.
+  # "unused" line matches \n at end.
+  # Result should be:
+  # <resources>\n    <string name="used">Value 1</string>\n</resources>
 
-    expected = """<resources>
+  expected = """<resources>
     <string name="used">Value 1</string>
 </resources>"""
 
-    assert _clean_xml_content(content, unused) == expected
+  assert _clean_xml_content(content, unused) == expected
+
 
 def test_clean_xml_content_consecutive() -> None:
-    content = """<resources>
+  content = """<resources>
     <string name="u1">v1</string>
     <string name="u2">v2</string>
     <string name="k1">v3</string>
 </resources>"""
-    unused = {"u1", "u2"}
+  unused = {"u1", "u2"}
 
-    expected = """<resources>
+  expected = """<resources>
     <string name="k1">v3</string>
 </resources>"""
 
-    assert _clean_xml_content(content, unused) == expected
+  assert _clean_xml_content(content, unused) == expected
+
 
 def test_clean_xml_content_with_empty_lines() -> None:
-    content = """<resources>
+  content = """<resources>
     <string name="u1">v1</string>
 
     <string name="u2">v2</string>
 </resources>"""
-    unused = {"u1"}
+  unused = {"u1"}
 
-    # Removing u1. u1 line ends with \n.
-    # There is an empty line (\n) after u1.
-    # Then u2.
-    # The regex consumes u1 line and its newline.
-    # The empty line remains.
+  # Removing u1. u1 line ends with \n.
+  # There is an empty line (\n) after u1.
+  # Then u2.
+  # The regex consumes u1 line and its newline.
+  # The empty line remains.
 
-    expected = """<resources>
+  expected = """<resources>
 
     <string name="u2">v2</string>
 </resources>"""
 
-    assert _clean_xml_content(content, unused) == expected
+  assert _clean_xml_content(content, unused) == expected
+
 
 def test_clean_xml_content_preserves_indentation() -> None:
-    content = """<resources>
+  content = """<resources>
     <string name="keep">v</string>
 </resources>"""
-    unused: set[str] = set()
+  unused: set[str] = set()
 
-    assert _clean_xml_content(content, unused) == content
+  assert _clean_xml_content(content, unused) == content
+
 
 def test_clean_xml_content_special_chars() -> None:
-    content = """<resources>
+  content = """<resources>
     <string name="s_1">Value "quoted"</string>
     <string name="s-2">Value &amp;</string>
 </resources>"""
-    unused = {"s_1"}
+  unused = {"s_1"}
 
-    expected = """<resources>
+  expected = """<resources>
     <string name="s-2">Value &amp;</string>
 </resources>"""
 
-    assert _clean_xml_content(content, unused) == expected
+  assert _clean_xml_content(content, unused) == expected
+
 
 def test_clean_xml_content_multiline_definition() -> None:
-    # Note: Our regex assumes <string ...>...</string> is effectively on one line
-    # (or rather, the regex uses .*? which doesn't match newlines without DOTALL).
-    # If the string definition spans multiple lines, the current implementation (and original)
-    # likely FAILS to match it properly if the newline is in the value.
-    # But let's verify what happens.
+  # Note: Our regex assumes <string ...>...</string> is effectively on one line
+  # (or rather, the regex uses .*? which doesn't match newlines without DOTALL).
+  # If the string definition spans multiple lines, the current implementation (and original)
+  # likely FAILS to match it properly if the newline is in the value.
+  # But let's verify what happens.
 
-    content = """<resources>
+  content = """<resources>
     <string name="multi">
         Line 1
         Line 2
     </string>
 </resources>"""
-    unused = {"multi"}
+  unused = {"multi"}
 
-    # Original regex: .*? without DOTALL -> does NOT match newline.
-    # So it won't match "Line 1\n...".
-    # So it won't be removed.
-    # This is existing behavior (limitation), we should probably preserve it or document it.
-    # Or if the original implementation didn't handle it, we shouldn't worry about it for optimization task.
-    # We will assert that it remains unchanged (or partially matched?)
+  # Original regex: .*? without DOTALL -> does NOT match newline.
+  # So it won't match "Line 1\n...".
+  # So it won't be removed.
+  # This is existing behavior (limitation), we should probably preserve it or document it.
+  # Or if the original implementation didn't handle it, we shouldn't worry about it for optimization task.
+  # We will assert that it remains unchanged (or partially matched?)
 
-    # Actually, <string ...> matches. .*? matches until newline.
-    # If the closing </string> is on a later line, the regex won't find it on the same line.
-    # So it fails to match.
+  # Actually, <string ...> matches. .*? matches until newline.
+  # If the closing </string> is on a later line, the regex won't find it on the same line.
+  # So it fails to match.
 
-    assert _clean_xml_content(content, unused) == content
+  assert _clean_xml_content(content, unused) == content


### PR DESCRIPTION
- Replaced `re.sub` with callback in `_clean_xml_content` with faster line iteration.
- Added `_CLEAN_STRING_PATTERN` constant for compiled regex.
- Fixed `.github/dependabot.yml` validation error by removing unsupported ecosystems (`uv`, `bun`).
- Verified with existing tests.

## Summary

## Changes
- 

## Testing
- [ ] Not run (explain)
- [ ] Tests run: 

## Checklist
- [ ] Scope is focused and related issues are linked
- [ ] Documentation updated if needed
- [ ] Tests added or updated where applicable
- [ ] No secrets or sensitive data included
